### PR TITLE
stepped down "console" and "process" dependencies to accommodate older php versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "description": "A command line tool to easily create and manage virtual hosts",
     "type": "metapackage",
     "require": {
-        "symfony/process": "^4.0",
-        "symfony/console": "^4.0"
+        "symfony/process": "^3.4",
+        "symfony/console": "^3.4"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
It happens that `symphony/process@v4.0` and `symphony/console@v4.0` only support the very latest `php ^7.1.3`, and lower versions of php 7 are still widely used.

Stepping down to `symphony/process@v3.4` and `symphony/console@v3.4` allows to accomodate `php ^5.5.9|>=7.0.8`